### PR TITLE
Adding ability to encrypt/decrypt buffers, which allows binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ const decryptedValue = crypto.decrypt(encryptedValue);
 should(decryptedValue).eql(unencryptedValue);
 ```
 
+You can also encrypt binary data using buffers:
+```
+const Crypto = require('node-crypt');
+const crypto = new Crypto({
+  key: 'b95d8cb128734ff8821ea634dc34334535afe438524a782152d11a5248e71b01',
+  hmacKey: 'dcf8cd2a90b1856c74a9f914abbb5f467c38252b611b138d8eedbe2abb4434fc'
+});
+
+// Have some data you want to protect
+const unencryptedValue = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f], 'binary');
+
+// Encrypt it
+const encryptedValue = crypto.encryptBuffer(unencryptedValue);
+
+// Decrypt it
+const decryptedValue = crypto.decryptBuffer(encryptedValue);
+should(decryptedValue).eql(unencryptedValue);
+```
+
+
 ### Proof in the Pudding
 As you can see here; encrypting the same string each time produces an entirely different value:
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -63,12 +63,55 @@ module.exports = function Crypto(options) {
     return decryptedText + decryptor.final('utf-8');
   };
 
+  const encryptBuffer = function (buffer) {
+    var IV = crypto.randomBytes(16);
+    var cipher;
+    var hmac;
+    var encryptor;
+
+    encryptor = crypto.createCipheriv(algo, key, IV);
+    cipher = Buffer.concat([encryptor.update(buffer), encryptor.final()]);
+
+    hmac = crypto.createHmac(hmacAlgo, hmacKey);
+    hmac.update(cipher);
+    hmac.update(IV);
+
+    return Buffer.concat([IV, hmac.digest(), cipher]);
+  };
+
+  const decryptBuffer = function (buffer) {
+    var IV = buffer.slice(0, 16);
+    var hmac = buffer.slice(16, 48);
+    var cipher = buffer.slice(48);
+    var decryptor;
+
+    const chmac = crypto.createHmac(hmacAlgo, hmacKey);
+    chmac.update(cipher);
+    chmac.update(IV);
+
+    if (!constantTimeCompare(chmac.digest('hex'), hmac.toString('hex'))) {
+      throw new Error('Encrypted Blob has been tampered with.');
+    }
+
+    decryptor = crypto.createDecipheriv(algo, key, IV);
+    const decrypted = Buffer.concat([decryptor.update(cipher), decryptor.final()]);
+    return decrypted;
+  };
+
   self.encrypt = function(arg) {
     return encrypt(arg);
   };
 
   self.decrypt = function(arg) {
     return decrypt(arg);
+  };
+
+  self.encryptBuffer = function(arg) {
+    return encryptBuffer(arg);
+  };
+
+  self.decryptBuffer = function(arg) {
+    return decryptBuffer(arg);
   };
 
   return self;

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -35,4 +35,32 @@ describe('Crypto', () => {
     should(decrypted).eql(value);
   });
 
+  it('shouldnt be able to decrypt buffer with another password', () => {
+    const value = Buffer.from('hide me');
+    const encrypted = crypto1.encryptBuffer(value);
+    const options = {
+      key: Buffer.from('a95d8cb128734ff8821ea634dc34334535afe438524a782152d11a5248e71b01', 'hex'),
+      hmacKey: Buffer.from('acf8cd2a90b1856c74a9f914abbb5f467c38252b611b138d8eedbe2abb4434fc', 'hex')
+    };
+    const anotherCrypto = new Crypto(options);
+
+    should(() => {
+      anotherCrypto.decryptBuffer(encrypted);
+    }).throw(/tampered with/);
+  });
+
+  it('should encrypt and decrypt buffer', () => {
+    const value = Buffer.from('hide me');
+    const encrypted = crypto1.encryptBuffer(value);
+    const decrypted = crypto2.decryptBuffer(encrypted);
+    should(decrypted).eql(value);
+  });
+
+  it('should encrypt and decrypt binary buffer', () => {
+    const value = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f], 'binary');
+    const encrypted = crypto1.encryptBuffer(value);
+    const decrypted = crypto2.decryptBuffer(encrypted);
+    should(decrypted).eql(value);
+  });
+
 });


### PR DESCRIPTION
This PR adds methods to encrypt and decrypt buffers. It uses the fixed size for the hmac and IV to slice the buffers accordingly, instead of using the | separator for binary data.