### PR TITLE
Upgrade lodash to 4.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "keywords": [],
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash": "4.17.10"
   }
 }


### PR DESCRIPTION
Lodash < 4.17.5 is considered as vulnerable by nsp or npm audit.